### PR TITLE
Do not directly throw from within tl_assert() if dialect is >=C++11

### DIFF
--- a/src/tl/tlAssert.h
+++ b/src/tl/tlAssert.h
@@ -27,6 +27,16 @@
 
 #include "tlCommon.h"
 
+// For >=C++11, mark assertion_failed() with attribute [[noreturn]] and call std::terminate().
+// Or else, throw int(0) to tell the compiler that the assertion will not return.
+#if __cplusplus < 201103L
+#define ATTRIB_ASSERT TL_PUBLIC
+#define END_ASSERT throw int(0)
+#else
+#define ATTRIB_ASSERT [[noreturn]] TL_PUBLIC
+#define END_ASSERT std::terminate()
+#endif
+
 namespace tl
 {
 
@@ -34,10 +44,9 @@ namespace tl
  *  @brief The corresponding assert macro
  */
 
-TL_PUBLIC void assertion_failed (const char *filename, unsigned int line, const char *condition);
+ATTRIB_ASSERT void assertion_failed (const char *filename, unsigned int line, const char *condition);
 
-//  the throw int(0) instruction will tell the compiler that the assertion will not return
-#define tl_assert(COND) if (!(COND)) { tl::assertion_failed (__FILE__, __LINE__, #COND); throw int(0); }
+#define tl_assert(COND) if (!(COND)) { tl::assertion_failed (__FILE__, __LINE__, #COND); END_ASSERT; }
 
 } // namespace tl
 


### PR DESCRIPTION
Building with >=C++11 (e.g., GCC-6), throwing an uncaught exception from within a destructor is generally considered dangerous and, when `-Werror=terminate` is forced in CXXFLAGS (as can be with Gentoo Linux, see [bug 612978](https://bugs.gentoo.org/show_bug.cgi?id=612978)) it will break the compile.  `tl_assert()` macro is expanded in some destructors (e.g., `Child::~Child()` from "src/unit_tests/tlXMLParser.cc").  Since function attribute `[[noreturn]]` is defined for >=C++11, better to use that instead of `throw int(0)`.